### PR TITLE
Added ability to customize pg databases with extensions

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,16 @@
+# Improvements
+
+- When custom databases are created, the manifest can be used to
+  specify any PG extensions that need to be loaded via the `extensions`
+  array attribute on the database.
+  Example:
+
+```
+properties:
+  pgpool:
+    databases:
+    - name: animals
+      extensions:
+      - citext
+      - pgcrypto
+```

--- a/jobs/postgres/spec
+++ b/jobs/postgres/spec
@@ -100,3 +100,5 @@ properties:
             users:
               - porcupine
               - hedgehog
+            extensions: # optional aray of extensions to enable on this database
+            - citext

--- a/jobs/postgres/templates/bin/ctl
+++ b/jobs/postgres/templates/bin/ctl
@@ -124,11 +124,17 @@ EOF
     echo >>$LOG_DIR/$JOB_NAME.log "[postgres] setting up database <%= database['name'] %>"
     set -x
 
-    createdb   -U vcap -p <%= port %>       -O vcap <%= database['name'] %> 
-
+    createdb   -U vcap -p <%= port %>       -O vcap <%= database['name'] %>
     <% database['users'].each do |user| %>
     psql -p <%= port %> -U vcap postgres -c "GRANT ALL PRIVILEGES ON DATABASE \"<%= database['name'] %>\" TO \"<%= user %>\""
     <% end %>
+
+    <% if database["extensions"]
+         database["extensions"].each do |ext| %>
+         echo "Trying to install <%= ext %>..."
+         psql -p <%= port %> -U vcap "<%= database['name'] %>" -c "CREATE EXTENSION IF NOT EXISTS <%= ext %>"
+    <%   end
+      end %>
 
     set +x
     echo

--- a/packages/postgres/packaging
+++ b/packages/postgres/packaging
@@ -13,5 +13,5 @@ VERSION=9.5.1
 tar -xjf postgres/postgresql-${VERSION}.tar.bz2
 cd postgresql-${VERSION}/
 ./configure --prefix ${BOSH_INSTALL_TARGET}
-make
-make install
+make world
+make install-world

--- a/templates/jobs.yml
+++ b/templates/jobs.yml
@@ -38,6 +38,9 @@ jobs:
             users:
               - porcupine
               - hedgehog
+            extensions:
+            - citext
+            - pgcypto
         users:
           - username: porcupine
             password: quill


### PR DESCRIPTION
The `pgpool.databases.extensions` array is now parsed to add
PG extensions into your databases. Additionally, postgres
is now compiled/installed with `world`, to include contrib,
and a bunch of postgres extensions.
