### PR TITLE
Upgrade to PostgreSQL 10.0

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# PostgreSQL v10
+
+See https://www.postgresql.org/about/news/1786/

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,13 +1,16 @@
----
-pgrt/pgrt:
-  object_id: b7968265-d373-404d-b6e0-12caa15f9f98
-  sha: 2f6c7cc5a7b89712be68f2663fdf3fa9f997a2fa
-  size: 7391896
-postgres/postgresql-9.5.1.tar.bz2:
-  object_id: c3acc49c-a9ec-49a1-ae82-e97a00672695
-  sha: 905bc31bc4d500e9498340407740a61835a2022e
-  size: 18441638
 pgpool2/pgpool-II-3.5.4.tar.gz:
+  size: 2237911
   object_id: c0821167-44de-470e-ad15-48309d6dd44a
   sha: 4ea15dc8bb740baf720b18f182b400ea60b1ae45
-  size: 2237911
+pgrt/pgrt:
+  size: 7391896
+  object_id: b7968265-d373-404d-b6e0-12caa15f9f98
+  sha: 2f6c7cc5a7b89712be68f2663fdf3fa9f997a2fa
+postgres/postgresql-10.0.tar.bz2:
+  size: 19639147
+  object_id: 5be63a34-5fb3-46c5-7c56-68ac25d47ee4
+  sha: 4c26f81278f7da12f46f2ff4fda5b0311e191b95
+postgres/postgresql-10.0.tar.bz2.sha256:
+  size: 90
+  object_id: 561fbed8-e591-4ff2-76cc-dc5ada3d604f
+  sha: 042385efc34f73a1b04081daf5ef5d9b11d49dbd

--- a/manifests/operators/dev.yml
+++ b/manifests/operators/dev.yml
@@ -1,0 +1,6 @@
+---
+- type: replace
+  path: /releases/name=postgres
+  value:
+    name: postgres
+    version: 2.latest

--- a/manifests/operators/pick-from-cloud-config.sh
+++ b/manifests/operators/pick-from-cloud-config.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# The base manifests/redis.yml assumes that your `bosh cloud-config` contains
+# "vm_type" and "networks" named "default". Its quite possible you don't have this.
+# This script will select the first "vm_types" and first "networks" to use in
+# your deployment. It will print to stderr the choices it made.
+#
+# Usage:
+#   bosh deploy manifests/redis.yml -o <(./manifests/operators/pick-from-cloud-config.sh)
+
+: ${BOSH_ENVIRONMENT:?required}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR/../..
+
+instance_groups=$(bosh int <(cat manifests/*.yml) --path /instance_groups | grep "^  name:" | awk '{print $2}' | sort | uniq)
+cloud_config=$(bosh cloud-config)
+vm_type=$(bosh int <(echo "$cloud_config") --path /vm_types/0/name)
+network=$(bosh int <(echo "$cloud_config") --path /networks/0/name)
+
+>&2 echo "vm_type: ${vm_type}, network: ${network}"
+
+for ig in $instance_groups; do
+cat <<YAML
+- type: replace
+  path: /instance_groups/name=${ig}/networks/name=default/name
+  value: ${network}
+
+- type: replace
+  path: /instance_groups/name=${ig}/vm_type
+  value: ${vm_type}
+
+YAML
+done
+

--- a/packages/postgres/packaging
+++ b/packages/postgres/packaging
@@ -8,24 +8,40 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 export HOME=/var/vcap
 
-# see https://ftp.postgresql.org/pub/source/v9.5.1/postgresql-9.5.1.tar.bz2
-VERSION=9.5.1
-tar -xjf postgres/postgresql-${VERSION}.tar.bz2
-cd postgresql-${VERSION}/
-patch -p1 <<EOF
-diff -u -ur postgresql-9.5.1.pristine/src/include/pg_config_manual.h postgresql-9.5.1/src/include/pg_config_manual.h
---- postgresql-9.5.1.pristine/src/include/pg_config_manual.h	2016-02-08 16:12:28.000000000 -0500
-+++ postgresql-9.5.1/src/include/pg_config_manual.h	2016-11-01 22:21:21.000000000 -0400
-@@ -169,7 +169,7 @@
-  * here's where to twiddle it.  You can also override this at runtime
-  * with the postmaster's -k switch.
-  */
--#define DEFAULT_PGSOCKET_DIR  "/tmp"
-+#define DEFAULT_PGSOCKET_DIR  "/var/vcap/sys/run/postgres"
- 
- /*
-  * This is the default event source for Windows event log.
-EOF
-./configure --prefix ${BOSH_INSTALL_TARGET}
-make world
-make install-world
+# see https://ftp.postgresql.org/pub/source/
+# see https://www.postgresql.org/ftp/source/
+
+cd postgres/
+sha256sum --check *.sha256
+cd -
+
+tar -xjf postgres/postgresql-*.tar.bz2
+
+pushd postgresql-* > /dev/null
+  if [[ "$(uname -a)" =~ "x86_64" || "$(uname -a)" =~ "ppc64le" ]] ; then
+    ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+  else
+    CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}"  --with-openssl
+  fi
+
+  pushd src/bin/pg_config > /dev/null
+    make -j$(nproc)
+    make install
+  popd > /dev/null
+
+  cp -LR src/include "${BOSH_INSTALL_TARGET}"
+  pushd src/interfaces/libpq > /dev/null
+    make -j$(nproc)
+    make install
+  popd > /dev/null
+
+  pushd src > /dev/null
+    make -j$(nproc)
+    make install
+  popd > /dev/null
+
+  pushd contrib > /dev/null
+    make -j$(nproc)
+    make install
+  popd > /dev/null
+popd > /dev/null

--- a/packages/postgres/spec
+++ b/packages/postgres/spec
@@ -2,4 +2,5 @@
 name: postgres
 dependencies: []
 files:
- - postgres/postgresql-9.5.1.tar.bz2
+ - postgres/postgresql-*.tar.bz2
+ - postgres/postgresql-*.tar.bz2.sha256


### PR DESCRIPTION
PostgreSQL v10.0 https://www.postgresql.org/about/news/1786/

**NOTE:** this is a starting place for a PR to move to PG v10.0.0; I created it so to allow others to dev/test this BOSH release but who might not have access to the bosh release's blobstore to upload the new blobs.

**Please don't merge unless it works, readme has been updated, and probably you'll bump the major version of the release to v3+ in CI**

To dev/test this branch:

```
git clone https://github.com/cloudfoundry-community/postgres-boshrelease -b pg10
cd postgres-boshrelease
export BOSH_ENVIRONMENT=<alias>
export BOSH_DEPLOYMENT=postgres
bosh create-release --force && bosh upload-release --rebase
bosh deploy manifests/postgres.yml -o manifests/operators/dev.yml -o <(./manifests/operators/pick-from-cloud-config.sh) --vars-store tmp/creds.yml
```